### PR TITLE
Updated link to graphframes package. Now it points to graphframes pac…

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@ Refer to the <a href="user-guide.html">User Guide</a> for a full list of queries
 
 <h1 id="downloading">Downloading</h1>
 
-<p>Get GraphFrames from the <a href="http://spark-packages.org">Spark Packages website</a>.
+<p>Get GraphFrames from the <a href="http://spark-packages.org/package/graphframes/graphframes">Spark Packages website</a>.
 This documentation is for GraphFrames version 0.1.
 GraphFrames depends on Apache Spark, which is available for download from the
 <a href="http://spark.apache.org">Apache Spark website</a>.</p>


### PR DESCRIPTION
…kage and not the homepage of spark package website.